### PR TITLE
Terminate on SIGINT/SIGTERM.

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"fmt"
 	"os"
+	"os/signal"
+	"syscall"
 
 	cli "github.com/codegangsta/cli"
 	path "github.com/ipfs/go-ipfs/path"
@@ -55,6 +57,14 @@ func main() {
 
 		return nil
 	}
+
+	// Catch interrupt signal
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sigs
+		os.Exit(1)
+	}()
 
 	app.Run(os.Args)
 }


### PR DESCRIPTION
Addresses #34. This doesn't clean up (elegantly close HTTP connection to API, shut down ephemeral node) but shouldn't cause any damage. We definitely want "safe shutdown" logic in place, but this will at least let users terminate the program should it hang on the network.