### PR TITLE
[WIP] Fix build, learn gx

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 # Minimum version numbers for software required to build IPFS
 IPFS_MIN_GO_VERSION = 1.7
-IPFS_MIN_GX_VERSION = 0.6
-IPFS_MIN_GX_GO_VERSION = 1.1
+IPFS_MIN_GX_VERSION = 0.12.1
+IPFS_MIN_GX_GO_VERSION = 1.6
 
-dist_root=/ipfs/QmVQJ5mEGT38nYTfe3ZCCZPJhFDXTzBekUb8x3v8Pifugt
-gx_bin=bin/gx-v0.11.0
-gx-go_bin=bin/gx-go-v1.4.0
+dist_root=/ipfs/QmfFqk8QBzV1nynPwUgiqmkqLLMt57vMiANT9gmeRGUBCw
+gx_bin=bin/gx-v0.12.1
+gx-go_bin=bin/gx-go-v1.6.0
 
 # use things in our bin before any other system binaries
 export PATH := bin:$(PATH)

--- a/main.go
+++ b/main.go
@@ -9,7 +9,7 @@ import (
 
 	path "gx/ipfs/QmQa2wf1sLFKkjHCVEbna8y5qhdMjL8vtTJSAc48vZGTer/go-ipfs/path"
 	cli "gx/ipfs/QmVcLF2CgjQb5BWmYFWsDfxDjbzBfcChfdHRedxeL3dV4K/cli"
-	fallback "gx/ipfs/Qmdk8Ea9GkbwHr7UNKVYaLRwwHSt69xBXuSvRVyNWZ9sZE/fallback-ipfs-shell"
+	fallback "gx/ipfs/QmWFzKEP8iYC6zDWsvp15UKDjfu2qbSqtCoJewozp6HZ9j/fallback-ipfs-shell"
 )
 
 func main() {

--- a/package.json
+++ b/package.json
@@ -7,15 +7,15 @@
   "gxDependencies": [
     {
       "author": "Stephen Whitmore <noffle@ipfs.io>",
-      "hash": "Qmdk8Ea9GkbwHr7UNKVYaLRwwHSt69xBXuSvRVyNWZ9sZE",
+      "hash": "QmWFzKEP8iYC6zDWsvp15UKDjfu2qbSqtCoJewozp6HZ9j",
       "name": "fallback-ipfs-shell",
-      "version": "3.2.4"
+      "version": "3.2.5"
     }
   ],
   "gxVersion": "0.7.0",
   "language": "go",
   "license": "",
   "name": "ipget",
-  "version": "0.2.5"
+  "version": "0.2.6"
 }
 


### PR DESCRIPTION
This PR aims  to fix build issues mentioned in https://github.com/ipfs/ipget/issues/48 and teach me some `gx` ;-)

Do not merge until all is solved:

- [x] fix mising pin for `ipfs-embedded-shell` (https://github.com/noffle/fallback-ipfs-shell/commit/d6e4759121401dc2be06e4d649acb4de2aaeb0b4)
    - [x] switch to latest `fallback-ipfs-shell` 
- [ ] fix `make install` 
- [ ] `gx publish` v0.2.6

----

@whyrusleeping  is the error below due to my lack of experience with `gx` or a real issue? 
Seems that `go install` fails due to non-gx transitive deps that I don't have locally.  Any tips how to solve it? 

```
make install
(..)
[done] [install] fallback-ipfs-shell      QmWFzKEP8iYC6zDWsvp15UKDjfu2qbSqtCoJewozp6HZ9j 0s
go install] 0s                                                                             
../../../gx/ipfs/QmdidTt1eZtEAn1Qv1rF9kHPusm57RkfNnsZsrQndsm8TT/go-ipfs-api/pubsub.go:7:2: cannot find package "github.com/libp2p/go-floodsub" in any of:
	/usr/lib64/go/src/github.com/libp2p/go-floodsub (from $GOROOT)
	/home/lidel/.local/gopath/src/github.com/libp2p/go-floodsub (from $GOPATH)
../../../gx/ipfs/QmdidTt1eZtEAn1Qv1rF9kHPusm57RkfNnsZsrQndsm8TT/go-ipfs-api/dag.go:11:2: cannot find package "github.com/whyrusleeping/go-multipart-files" in any of:
	/usr/lib64/go/src/github.com/whyrusleeping/go-multipart-files (from $GOROOT)
	/home/lidel/.local/gopath/src/github.com/whyrusleeping/go-multipart-files (from $GOPATH)
make: *** [Makefile:38: install] Error 1
```

