### PR TITLE
Add input cleaner

### DIFF
--- a/sharness/t0030-arguments.sh
+++ b/sharness/t0030-arguments.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+test_description="test the ipget argument parser"
+
+. ./lib/sharness/sharness.sh
+
+test_expect_success "retrieve a known popular single file with a (HTTP) gateway URL" "
+    ipget http://ipfs.io/ipfs/QmQ2r6iMNpky5f1m4cnm3Yqw8VSvjuKpTcK1X7dBR1LkJF/cat.gif &&
+    echo 'c5ea0d6cacf1e54635685803ec4edbe0d4fe8465' > expected &&
+    shasum cat.gif | cut -d ' ' -f 1 > actual &&
+    diff expected actual
+"
+
+test_expect_success "retrieve a known popular single file with browser protocol URI" "
+    ipget ipfs://QmQ2r6iMNpky5f1m4cnm3Yqw8VSvjuKpTcK1X7dBR1LkJF/cat.gif &&
+    echo 'c5ea0d6cacf1e54635685803ec4edbe0d4fe8465' > expected &&
+    shasum cat.gif | cut -d ' ' -f 1 > actual &&
+    diff expected actual
+"
+
+test_expect_failure "don't allow non-(HTTP)gateway URLS" "
+    ipget ftp://ipfs.io/ipfs/QmQ2r6iMNpky5f1m4cnm3Yqw8VSvjuKpTcK1X7dBR1LkJF/cat.gif
+"
+
+test_done


### PR DESCRIPTION
So that input such as `http://localhost:8080/ipfs/QmcbLLZJa9oXnYTZWfS4T16n8B2mHFZkAzkKBNdGVzgG8g`, `https://ipfs.io/ipfs/QmcbLLZJa9oXnYTZWfS4T16n8B2mHFZkAzkKBNdGVzgG8g`, etc. may be passed in and turned into proper references (`/ipfs/QmcbLLZJa9oXnYTZWfS4T16n8B2mHFZkAzkKBNdGVzgG8g`)
If nothing is found the input string is returned so that it may pass or fail by `path.ParsePath` later.

Blocked by: https://github.com/ipfs/ipget/pull/50
submitting now so I don't forget.