### PR TITLE
release 0.3.1

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-0.3.0: QmPjrHqppYZcDHqrjoikgzzchLJaVhd8aL9bhZdT8SfXgS
+0.3.1: QmQjiUCpboAMirdSu3naKvpJqNoy5qJUQ6WCeF4CUytVDA

--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
   "language": "go",
   "license": "",
   "name": "ipget",
-  "version": "0.3.0"
+  "version": "0.3.1"
 }
 


### PR DESCRIPTION
0.3.0 was never properly released and appears to have been tagged before 0.2.5?

Let's just skip to 0.3.1 and pretend this never happened.