### PR TITLE
inform users about the temp node option in CLI

### DIFF
--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ func main() {
 		},
 		cli.StringFlag{
 			Name:  "node,n",
-			Usage: "specify ipfs node strategy ('local', 'spawn', or 'fallback')",
+			Usage: "specify ipfs node strategy ('local', 'spawn', `temp` or 'fallback')",
 			Value: "fallback",
 		},
 		cli.StringSliceFlag{


### PR DESCRIPTION
Pretty self explanatory, there's no way a user will know about the temp option without reading the code.