### PR TITLE
Stop using badger for temporary nodes

### DIFF
--- a/node.go
+++ b/node.go
@@ -102,10 +102,6 @@ func tmpNode(ctx context.Context) (iface.CoreAPI, error) {
 	// configure the temporary node
 	cfg.Routing.Type = "dhtclient"
 	cfg.Experimental.QUIC = true
-	cfg.Datastore.Spec = map[string]interface{}{
-		"type": "badgerds",
-		"path": "badger",
-	}
 
 	err = fsrepo.Init(dir, cfg)
 	if err != nil {


### PR DESCRIPTION
Every time we create a new temp node with Badger is 2GB of space down the drain. Either we need a smaller default badger repo, use FlatFS, or even use a memory repo.

For now I've just removed the badger settings which will use the defaults (currently FlatFS), but am up for other suggestions.