### PR TITLE
Cleanup temp directory on exit

### DIFF
--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ func main() {
 	app := cli.NewApp()
 	app.Name = "ipget"
 	app.Usage = "Retrieve and save IPFS objects."
-	app.Version = "0.5.0"
+	app.Version = "0.7.0"
 	app.Flags = []cli.Flag{
 		&cli.StringFlag{
 			Name:    "output",

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	gopath "path"
 	"path/filepath"
 	"strings"
+	"sync"
 	"syscall"
 
 	files "github.com/ipfs/go-ipfs-files"
@@ -19,11 +20,19 @@ import (
 	pb "gopkg.in/cheggaaa/pb.v1"
 )
 
+var (
+	cleanup      []func() error
+	cleanupMutex sync.Mutex
+)
+
 func main() {
+	// Do any cleanup on exit
+	defer doCleanup()
+
 	app := cli.NewApp()
 	app.Name = "ipget"
 	app.Usage = "Retrieve and save IPFS objects."
-	app.Version = "0.7.0"
+	app.Version = "0.5.0"
 	app.Flags = []cli.Flag{
 		&cli.StringFlag{
 			Name:    "output",
@@ -124,6 +133,7 @@ func main() {
 	err := app.Run(args)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
+		doCleanup()
 		os.Exit(1)
 	}
 }
@@ -228,5 +238,22 @@ func writeToRec(nd files.Node, fpath string, bar *pb.ProgressBar) error {
 		return entries.Err()
 	default:
 		return fmt.Errorf("file type %T at %q is not supported", nd, fpath)
+	}
+}
+
+func addCleanup(f func() error) {
+	cleanupMutex.Lock()
+	defer cleanupMutex.Unlock()
+	cleanup = append(cleanup, f)
+}
+
+func doCleanup() {
+	cleanupMutex.Lock()
+	defer cleanupMutex.Unlock()
+
+	for _, f := range cleanup {
+		if err := f(); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+		}
 	}
 }

--- a/node.go
+++ b/node.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/ipfs/go-ipfs-config"
@@ -94,6 +95,11 @@ func tmpNode(ctx context.Context) (iface.CoreAPI, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to get temp dir: %s", err)
 	}
+
+	// Cleanup temp dir on exit
+	addCleanup(func() error {
+		return os.RemoveAll(dir)
+	})
 
 	identity, err := config.CreateIdentity(ioutil.Discard, []options.KeyGenerateOption{
 		options.Key.Type(options.Ed25519Key),


### PR DESCRIPTION
When `ipget` uses an ephemeral node it creates a temporary directory, `/tmp/ipfs-shellxxx`, every time `ipget` is run.  With this PR, `ipget` removes the temp directory on exit.