### PR TITLE
Help message shows tagged build version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 # Minimum version numbers for software required to build IPFS
-IPFS_MIN_GO_VERSION = 1.14
+IPFS_MIN_GO_VERSION = 1.15
+VERSION = $(shell git describe --tags)
 
 # use things in our bin before any other system binaries
 export PATH := bin:$(PATH)
@@ -14,7 +15,7 @@ install: deps
 	go install
 
 build: deps
-	go build
+	go build -ldflags="-X 'main.version=${VERSION}'"
 
 clean:
 	rm -rf ./ipget

--- a/main.go
+++ b/main.go
@@ -19,11 +19,13 @@ import (
 	pb "gopkg.in/cheggaaa/pb.v1"
 )
 
+var version string
+
 func main() {
 	app := cli.NewApp()
 	app.Name = "ipget"
 	app.Usage = "Retrieve and save IPFS objects."
-	app.Version = "0.7.0"
+	app.Version = version
 	app.Flags = []cli.Flag{
 		&cli.StringFlag{
 			Name:    "output",


### PR DESCRIPTION
If current commit is not matched by tag, then also show commit.

Fixes issue #30