### PR TITLE
fix: update help and README to v0.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,16 +52,18 @@ USAGE:
    ipget [global options] command [command options] [arguments...]
 
 VERSION:
-   0.7.0
+   0.8.0
 
 COMMANDS:
+   help, h  Shows a list of commands or help for one command
+
 GLOBAL OPTIONS:
    --output value, -o value  specify output location
-   --node temp, -n temp      specify ipfs node strategy ('local', 'spawn', temp or 'fallback') (default: "fallback")
+   --node value, -n value    specify ipfs node strategy ("local", "spawn", "temp" or "fallback") (default: "fallback")
    --peers value, -p value   specify a set of IPFS peers to connect to
-   --progress                show a progress bar
-   --help, -h                show help
-   --version, -v             print the version
+   --progress                show a progress bar (default: false)
+   --help, -h                show help (default: false)
+   --version, -v             print the version (default: false)
 ```
 
 ## Contribute

--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ func main() {
 	app := cli.NewApp()
 	app.Name = "ipget"
 	app.Usage = "Retrieve and save IPFS objects."
-	app.Version = "0.7.0"
+	app.Version = "0.8.0"
 	app.Flags = []cli.Flag{
 		&cli.StringFlag{
 			Name:    "output",


### PR DESCRIPTION
Prior to this commit, `ipget` reported its version as 0.7.0 which is
not correct.

Please note that I don't know if that is all that's needed, I just grepped for `0.7.0` and replaced it.