### PR TITLE
chore: Upgrade github.com/cockroachdb/swiss for Go 1.25 support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/cockroachdb/logtags v0.0.0-20230118201751-21c54148d20b // indirect
 	github.com/cockroachdb/pebble/v2 v2.0.3 // indirect
 	github.com/cockroachdb/redact v1.1.5 // indirect
-	github.com/cockroachdb/swiss v0.0.0-20250327203710-2932b022f6df // indirect
+	github.com/cockroachdb/swiss v0.0.0-20250624142022-d6e517c1d961 // indirect
 	github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06 // indirect
 	github.com/containerd/cgroups v1.1.0 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -101,8 +101,8 @@ github.com/cockroachdb/pebble/v2 v2.0.3 h1:YJ3Sc9jRN/q6OOCNyRHPbcpenbxL1DdgdpUqP
 github.com/cockroachdb/pebble/v2 v2.0.3/go.mod h1:NgxgNcWwyG/uxkLUZGM2aelshaLIZvc0hCX7SCfaO8s=
 github.com/cockroachdb/redact v1.1.5 h1:u1PMllDkdFfPWaNGMyLD1+so+aq3uUItthCFqzwPJ30=
 github.com/cockroachdb/redact v1.1.5/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
-github.com/cockroachdb/swiss v0.0.0-20250327203710-2932b022f6df h1:GUJ4KuZtbOcIfRlprHJFFvIqQ4irtQUl+1fJr+yNmPI=
-github.com/cockroachdb/swiss v0.0.0-20250327203710-2932b022f6df/go.mod h1:yBRu/cnL4ks9bgy4vAASdjIW+/xMlFwuHKqtmh3GZQg=
+github.com/cockroachdb/swiss v0.0.0-20250624142022-d6e517c1d961 h1:Nua446ru3juLHLZd4AwKNzClZgL1co3pUPGv3o8FlcA=
+github.com/cockroachdb/swiss v0.0.0-20250624142022-d6e517c1d961/go.mod h1:yBRu/cnL4ks9bgy4vAASdjIW+/xMlFwuHKqtmh3GZQg=
 github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06 h1:zuQyyAKVxetITBuuhv3BI9cMrmStnpT18zmgmTxunpo=
 github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06/go.mod h1:7nc4anLGjupUW/PeY5qiNYsdNXj7zopG+eqsS7To5IQ=
 github.com/containerd/cgroups v0.0.0-20201119153540-4cbc285b3327/go.mod h1:ZJeTFisyysqgcCdecO57Dj79RfL0LNeGiFUqLYQRYLE=


### PR DESCRIPTION
Go 1.25 incompatibility detected in
* https://github.com/Homebrew/homebrew-core/pull/226636

then:
* reported upstream in https://github.com/cockroachdb/swiss/issues/48
* fixed upstream https://github.com/cockroachdb/swiss/pull/49

This PR brings just this upstream fix upstream to ipfs. Alternatively we could wait until
* https://github.com/ipfs/kubo/pull/10850

is merged and released an then upgrade the `github.com/ipfs/kubo` direct dependancy.

### Details:

Before:
```
go1.25rc1 build ./...
github.com/cockroachdb/swiss
# github.com/cockroachdb/swiss
github.com/cockroachdb/swiss
# github.com/cockroachdb/swiss
../../../go/pkg/mod/github.com/cockroachdb/swiss@v0.0.0-20250327203710-2932b022f6df/map.go:286:7: undefined: hashFn
../../../go/pkg/mod/github.com/cockroachdb/swiss@v0.0.0-20250327203710-2932b022f6df/map.go:337:14: undefined: getRuntimeHasher
../../../go/pkg/mod/github.com/cockroachdb/swiss@v0.0.0-20250327203710-2932b022f6df/map.go:338:22: undefined: fastrand64
../../../go/pkg/mod/github.com/cockroachdb/swiss@v0.0.0-20250327203710-2932b022f6df/map.go:600:23: undefined: fastrand64
../../../go/pkg/mod/github.com/cockroachdb/swiss@v0.0.0-20250327203710-2932b022f6df/map.go:649:19: undefined: fastrand64
../../../go/pkg/mod/github.com/cockroachdb/swiss@v0.0.0-20250327203710-2932b022f6df/map.go:670:20: undefined: fastrand64
../../../go/pkg/mod/github.com/cockroachdb/swiss@v0.0.0-20250327203710-2932b022f6df/options.go:30:14: undefined: hashFn
```

Upgrade:
```
go get -u github.com/cockroachdb/swiss && go mod tidy
go: upgraded github.com/cockroachdb/swiss v0.0.0-20250327203710-2932b022f6df => v0.0.0-20250624142022-d6e517c1d961
```

After:
```
go1.25rc1 build ./...
```
(build successful)