### PR TITLE
Don't announce any addresses with temporary repo

### DIFF
--- a/node.go
+++ b/node.go
@@ -118,6 +118,8 @@ func tmpNode(ctx context.Context) (iface.CoreAPI, error) {
 	}
 
 	// configure the temporary node
+	cfg.Addresses.Announce = nil // Don't announce any addresses
+
 	cfg.Routing.Type = config.NewOptionalString("dhtclient")
 
 	cfg.Datastore.NoSync = true


### PR DESCRIPTION
Previously all detected IP addresses were announced!

In addition to being a potentially serious privacy/security issue, that behavior poisons content retrieval because the node is only alive as long as download is in progress.