### PR TITLE
remove "-dev-build" from version output

### DIFF
--- a/version.go
+++ b/version.go
@@ -47,5 +47,5 @@ func buildVersion() string {
 	if revision != "" {
 		return fmt.Sprintf("%s %s-%s", release, day, revision)
 	}
-	return release + " dev-build"
+	return release
 }


### PR DESCRIPTION
The sting "-dev-build" is added to the versio output when the build info does not contain a `vcs.revision` value. This happens when ipget is installed using `go install`, which makes the meaning of "dev-build" confusing since unmodified code was used to build ipget, and downloadable binaries are not offered.